### PR TITLE
Bump rack-openid to include recent fixes.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,9 @@ GIT
 PATH
   remote: .
   specs:
-    omniauth-openid (1.0.0.beta1)
-      omniauth (~> 1.0.0.beta1)
-      rack-openid (~> 1.3.1)
+    omniauth-openid (1.0.1)
+      omniauth (~> 1.0)
+      rack-openid (~> 1.4.2)
 
 GEM
   remote: http://rubygems.org/
@@ -22,13 +22,13 @@ GEM
       thor (~> 0.14.6)
     guard-rspec (0.5.0)
       guard (>= 0.8.4)
-    hashie (1.2.0)
+    hashie (2.0.5)
     multi_json (1.0.3)
-    omniauth (1.0.0.pr2)
-      hashie
-      rack
+    omniauth (1.2.1)
+      hashie (>= 1.2, < 3)
+      rack (~> 1.0)
     rack (1.3.5)
-    rack-openid (1.3.1)
+    rack-openid (1.4.2)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
     rack-protection (1.1.2)
@@ -57,7 +57,7 @@ GEM
     thor (0.14.6)
     tilt (1.3.3)
     webmock (1.7.7)
-      addressable (> 2.2.5, ~> 2.2)
+      addressable (~> 2.2, > 2.2.5)
       crack (>= 0.1.7)
     yard (0.7.2)
 
@@ -74,7 +74,7 @@ DEPENDENCIES
   rake (~> 0.8)
   rb-fsevent
   rdiscount (~> 1.6)
-  rspec (~> 2.5)
+  rspec (~> 2.7)
   ruby-openid (= 2.1.8)!
   simplecov (~> 0.4)
   sinatra

--- a/lib/omniauth-openid/version.rb
+++ b/lib/omniauth-openid/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module OpenID
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end

--- a/omniauth-openid.gemspec
+++ b/omniauth-openid.gemspec
@@ -4,7 +4,7 @@ require File.expand_path('../lib/omniauth-openid/version', __FILE__)
 Gem::Specification.new do |gem|
 
   gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'rack-openid', '~> 1.3.1'
+  gem.add_dependency 'rack-openid', '~> 1.4.2'
   gem.add_development_dependency 'rack-test', '~> 0.5'
   gem.add_development_dependency 'rake', '~> 0.8'
   gem.add_development_dependency 'rdiscount', '~> 1.6'


### PR DESCRIPTION
Some of them are integral to our application. We have a temporary
version hack running on our local fork at the moment.

See https://github.com/grosser/rack-openid/pull/4 for more discussion.
